### PR TITLE
Add token-protected registry API

### DIFF
--- a/microservices/module-store/.gitignore
+++ b/microservices/module-store/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+modules.db

--- a/microservices/module-store/README.md
+++ b/microservices/module-store/README.md
@@ -1,0 +1,26 @@
+# Module Store Service
+
+A simple backend module storage service built with [Bun](https://bun.sh/), [Elysia](https://elysiajs.com) and [Kysely](https://kysely.dev) using Bun's built in SQLite driver.
+
+The service exposes a minimal HTTP API for storing and retrieving small JavaScript modules (up to **100 KB**).
+
+## API
+
+All routes are prefixed with `/registry`.
+
+- `POST /registry/module` – create a module. Requires header `Authorization: Bearer <token>` with `MODULE_TOKEN`.
+- `GET /registry/module/:name` – fetch stored module code by name.
+- `GET /registry/modules` – list available modules.
+- `DELETE /registry/module/:name` – remove a module.
+
+## Development
+
+Install dependencies and run the service:
+
+```bash
+bun install
+bun run src/index.ts
+```
+
+Set `MODULE_TOKEN` in the environment to control who can upload modules. The database is stored in `modules.db`.
+

--- a/microservices/module-store/package.json
+++ b/microservices/module-store/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "module-store",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/index.ts"
+  },
+  "dependencies": {
+    "elysia": "latest",
+    "kysely": "latest"
+  }
+}

--- a/microservices/module-store/src/index.ts
+++ b/microservices/module-store/src/index.ts
@@ -1,0 +1,69 @@
+import { Elysia } from 'elysia'
+import { Database } from 'bun:sqlite'
+import { Kysely, SqliteDialect, sql } from 'kysely'
+
+interface ModuleTable {
+  name: string
+  code: string
+  created_at: string
+}
+
+interface DB {
+  modules: ModuleTable
+}
+
+const db = new Kysely<DB>({
+  dialect: new SqliteDialect({
+    database: new Database('modules.db')
+  })
+})
+
+await db.schema
+  .createTable('modules')
+  .ifNotExists()
+  .addColumn('name', 'text', col => col.primaryKey())
+  .addColumn('code', 'text', col => col.notNull())
+  .addColumn('created_at', 'text', col => col.defaultTo(sql`CURRENT_TIMESTAMP`))
+  .execute()
+
+const AUTH_TOKEN = Bun.env.MODULE_TOKEN ?? ''
+const app = new Elysia({ prefix: '/registry' })
+
+app.get('/modules', async () => {
+  return db.selectFrom('modules').select(['name', 'created_at']).execute()
+})
+
+app.get('/module/:name', async ({ params }) => {
+  const row = await db
+    .selectFrom('modules')
+    .select('code')
+    .where('name', '=', params.name)
+    .executeTakeFirst()
+  if (!row) return new Response('Not Found', { status: 404 })
+  return row.code
+})
+
+app.post('/module', async ({ request, body }) => {
+  const auth = request.headers.get('authorization') ?? ''
+  if (auth !== `Bearer ${AUTH_TOKEN}`)
+    return new Response('Unauthorized', { status: 401 })
+
+  const { name, code } = (body ?? {}) as Record<string, string>
+  if (!name || !code) return new Response('Bad Request', { status: 400 })
+  if (code.length > 100 * 1024)
+    return new Response('Payload Too Large', { status: 413 })
+  try {
+    await db.insertInto('modules').values({ name, code }).execute()
+    return { status: 'ok' }
+  } catch {
+    return new Response('Conflict', { status: 409 })
+  }
+})
+
+app.delete('/module/:name', async ({ params }) => {
+  await db.deleteFrom('modules').where('name', '=', params.name).execute()
+  return { status: 'deleted' }
+})
+
+app.listen(3000)
+console.log('Module store running at http://localhost:3000/registry')


### PR DESCRIPTION
## Summary
- extend the Bun+Elysia module store with a `/registry` API prefix
- require a `MODULE_TOKEN` bearer token when uploading modules
- switch database access to Kysely

## Testing
- `bun install` *(fails: 403 to registry.npmjs.org)*
- `bun run src/index.ts` *(fails: Cannot find package 'elysia')*

------
https://chatgpt.com/codex/tasks/task_e_684b9ff63be48328a15308552a9a81c1